### PR TITLE
feat: create channel and MRSS feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Once up and running the service is by default available on port `8080` unless ot
 | -------- | ------ | ----------- |
 | `/api/docs/` | GET | API documentation (Swagger) |
 | `/api/v1/channels`| GET | List available channels |
+| `/api/v1/channels`| POST | Create a new channel |
 | `/api/v1/channels/{channelId}`| DELETE | Remove a channel (TBD) |
 | `/api/v1/channels/{channelId}/schedule`| GET | Obtain the schedule for a channel |
 
@@ -87,7 +88,7 @@ The MRSS auto scheduler automatically adds new schedule events on a channel base
 | ENDPOINT | METHOD | DESCRIPTION |
 | -------- | ------ | ----------- |
 | `/api/v1/mrss` | GET | List of running MRSS schedulers |
-| `/api/v1/mrss` | POST | Add a new MRSS scheduler (TBD) |
+| `/api/v1/mrss` | POST | Add a new MRSS scheduler (channel must exist) |
 | `/api/v1/mrss` | DELETE | Remove an MRSS scheduler but keeping the channel |
 
 ### Example

--- a/src/api/channels.ts
+++ b/src/api/channels.ts
@@ -19,7 +19,7 @@ interface IAPIScheduleQuery {
 }
 
 const ChannelsAPI: FastifyPluginAsync = async (fastify: FastifyInstance, options: FastifyPluginOptions) => {
-  const { prefix } = options;
+  const { prefix } = options;
 
   fastify.register(async (server: FastifyInstance) => {
     server.get("/channels", {
@@ -36,6 +36,7 @@ const ChannelsAPI: FastifyPluginAsync = async (fastify: FastifyInstance, options
           const channels: Channel[] = await server.db.channels.listAll();
           return reply.code(200).send(channels);
         } else {
+          request.log.info(`Listing channels for tenant '${tenant}'`);
           const channels: Channel[] = await server.db.channels.list(tenant);
           return reply.code(200).send(channels);
         }

--- a/src/models/channelModel.ts
+++ b/src/models/channelModel.ts
@@ -1,4 +1,4 @@
-import { Type } from '@sinclair/typebox'
+import { Type, Static } from '@sinclair/typebox'
 
 export interface ChannelAttrs {
   id: string;
@@ -6,14 +6,17 @@ export interface ChannelAttrs {
   title: string;
 }
 
+export const ChannelSchema = Type.Object({
+  id: Type.String(),
+  tenant: Type.String(),
+  title: Type.String(),
+});
+export type ChannelType = Static<typeof ChannelSchema>;
+
 export class Channel {
   private attrs: ChannelAttrs;
 
-  public static schema = Type.Object({
-    id: Type.String(),
-    tenant: Type.String(),
-    title: Type.String(),
-  });
+  public static schema = ChannelSchema;
 
   constructor(attrs: ChannelAttrs) {
     this.attrs = {

--- a/src/models/mrssFeedModel.ts
+++ b/src/models/mrssFeedModel.ts
@@ -2,7 +2,7 @@ import fetch from "node-fetch";
 import xmlparser from "fast-xml-parser";
 import dayjs from "dayjs";
 import Debug from "debug";
-import { Type } from '@sinclair/typebox'
+import { Type, Static } from '@sinclair/typebox'
 
 import { hlsduration } from "@eyevinn/hls-duration";
 
@@ -34,22 +34,25 @@ interface MRSSCache {
   assets: MRSSAsset[];
 }
 
+export const MRSSFeedSchema = Type.Object({
+  id: Type.String(),
+  tenant: Type.String(),
+  url: Type.String(),
+  channelId: Type.String(),
+  config: Type.Object({
+    scheduleRetention: Type.Optional(Type.Number()),
+    liveEventFrequency: Type.Optional(Type.Number()),
+    liveUrl: Type.Optional(Type.String()),
+  })
+});
+export type MRSSFeedType = Static<typeof MRSSFeedSchema>;
+
 export class MRSSFeed {
   private attrs: MRSSFeedAttr;
   private cache: MRSSCache;
   private liveEventCountdown: number;
 
-  public static schema = Type.Object({
-    id: Type.String(),
-    tenant: Type.String(),
-    url: Type.String(),
-    channelId: Type.String(),
-    config: Type.Object({
-      scheduleRetention: Type.Optional(Type.Number()),
-      liveEventFrequency: Type.Optional(Type.Number()),
-      liveUrl: Type.Optional(Type.String()),
-    }),
-  });
+  public static schema = MRSSFeedSchema;
 
   constructor(attrs: MRSSFeedAttr) {
     this.attrs = {


### PR DESCRIPTION
This PR addresses #10 and adds the functionality to add an MRSS feed for the MRSS autoscheduler for a channel. It also adds the functionality to add a new channel.